### PR TITLE
fix: 秒杀初始化信息接口可能会出错的BUG，频率还是挺高

### DIFF
--- a/jd_mask_spider_requests.py
+++ b/jd_mask_spider_requests.py
@@ -175,7 +175,10 @@ class Jd_Mask_Spider(object):
             'Host': 'marathon.jd.com',
         }
         resp = self.session.post(url=url, data=data, headers=headers)
-        return parse_json(resp.text)
+        if resp.text != 'null':
+            return parse_json(resp.text)
+        else:
+            return self._get_seckill_init_info()
 
     def _get_seckill_order_data(self):
         """生成提交抢购订单所需的请求体参数


### PR DESCRIPTION
这个接口很容易出错，在秒杀时段，基本上需要请求2 -4次才会返回成功的用户信息。